### PR TITLE
Setting for the # of messages per backlog

### DIFF
--- a/config/settings.go
+++ b/config/settings.go
@@ -27,6 +27,7 @@ type General struct {
 	EnableNotifications bool
 	UseTerminalBell     bool
 	NotificationTimeout int64
+	BacklogMsgQuantity 	int
 }
 
 type Keymap struct {
@@ -79,6 +80,7 @@ var Config = IniFile{
 		EnableNotifications: false,
 		UseTerminalBell:     false,
 		NotificationTimeout: 60,
+		BacklogMsgQuantity:	 10,
 	},
 	&Keymap{
 		SwitchPanels:    "Tab",

--- a/config/settings.go
+++ b/config/settings.go
@@ -27,7 +27,7 @@ type General struct {
 	EnableNotifications bool
 	UseTerminalBell     bool
 	NotificationTimeout int64
-	BacklogMsgQuantity 	int
+	BacklogMsgQuantity  int
 }
 
 type Keymap struct {
@@ -80,7 +80,7 @@ var Config = IniFile{
 		EnableNotifications: false,
 		UseTerminalBell:     false,
 		NotificationTimeout: 60,
-		BacklogMsgQuantity:	 10,
+		BacklogMsgQuantity:  10,
 	},
 	&Keymap{
 		SwitchPanels:    "Tab",

--- a/main.go
+++ b/main.go
@@ -427,7 +427,7 @@ func PrintCommands() {
 	fmt.Fprintln(textView, "[::b] "+cmdPrefix+"quit [::-]or[::b]", config.Config.Keymap.CommandQuit, "[::-] = Exit app")
 	fmt.Fprintln(textView, "")
 	fmt.Fprintln(textView, "[-::-]Chat[-::-]")
-	fmt.Fprintln(textView, "[::b] "+cmdPrefix+"backlog [::-]or[::b]", config.Config.Keymap.CommandBacklog, "[::-] = load next 10 previous messages")
+	fmt.Fprintln(textView, "[::b] "+cmdPrefix+"backlog [::-]or[::b]", config.Config.Keymap.CommandBacklog, "[::-] = load next "+config.Config.General.BacklogMsgQuantity+" previous messages")
 	fmt.Fprintln(textView, "[::b] "+cmdPrefix+"read [::-]or[::b]", config.Config.Keymap.CommandRead, "[::-] = mark new messages in chat as read")
 	fmt.Fprintln(textView, "[::b] "+cmdPrefix+"upload[::-] /path/to/file  = Upload any file as document")
 	fmt.Fprintln(textView, "[::b] "+cmdPrefix+"sendimage[::-] /path/to/file  = Send image message")

--- a/messages/session_manager.go
+++ b/messages/session_manager.go
@@ -279,7 +279,7 @@ func (sm *SessionManager) execCommand(command Command) {
 		sm.uiHandler.PrintText("[" + config.Config.Colors.Negative + "]Unknown command: [-]" + cmd)
 	case "backlog":
 		if sm.currentReceiver != "" {
-			count := 10
+			count := config.Config.General.BacklogMsgQuantity
 			if currentMsgs, ok := sm.db.textMessages[sm.currentReceiver]; ok {
 				if len(currentMsgs) > 0 {
 					firstMsg := currentMsgs[0]


### PR DESCRIPTION
This adds a customizable setting to define how many messages to retrieve per backlog cmd execution.